### PR TITLE
feat: modernize the starter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # djangovue
 ![Vue.js Logo](https://github.com/mikebz/djangovue/raw/master/frontend/img/logo.png "Vue.js")
 
-This is a starter project for Django with Vue.js.  I fell in love with the readability you get in Vue.js and
-decided to create a project where all components are laid out in the most readable way.
-
-The frontend uses Vue 3 + Vite, and the backend uses Django 5 with environment-driven settings.
+This is a starter project for Django with Vue.js. The frontend uses Vue 3 + Vite, and the backend uses
+Django 5 with environment-driven settings.
 
 ## ⚡ Modern Package Management (UV)
 
@@ -53,7 +51,10 @@ uv run python manage.py runserver
 make run
 ```
 
-At this point you should be able to navigate to localhost:8000 and see a template rendered.
+At this point you should be able to navigate to localhost:8000 and see the starter page render.
+
+If you are coming from a webpack-based workflow, note that this project does not use Babel or webpack.
+Vite handles the frontend build, and the `make` targets mirror the same commands used in CI.
 
 ## 🛠️ Development Commands
 
@@ -157,12 +158,12 @@ make prod-build
 make docker-build
 ```
 
-## �📦 What's New
+## What's New
 
 - **Python 3.11+** required (upgraded from 3.10+, using Python 3.13.5)
 - **Django 5.1** (upgraded from 4.2)
 - **UV package manager** for faster dependency management
-- **Vite 6.x** build tool (replaced Webpack 3.x) - 50x faster dev server
+- **Vite 6.x** build tool for fast dev server startup and lean production bundles
 - **Vue 3.5** (upgraded from Vue 2.x, latest Vue with Composition API)
 - **Hot Module Replacement (HMR)** for instant development feedback
 - **Modern linting** with Ruff (replaces pylint)
@@ -186,6 +187,7 @@ If you're upgrading from the old setup:
 - **Automated security scanning** monitors for vulnerabilities
 
 ## Sources
-This only worked because people before me created some wonderful examples.
-- https://github.com/djstein/vue-django-webpack
-- https://github.com/ezhome/django-webpack-loader
+This project builds on the Django, Vue, and Vite ecosystems.
+- https://vuejs.org/
+- https://vite.dev/
+- https://docs.djangoproject.com/

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ make docker-build
 
 ## What's New
 
-- **Python 3.11+** required (upgraded from 3.10+, using Python 3.13.5)
+- **Python 3.11+** required (upgraded from 3.10+, CI uses Python 3.13)
 - **Django 5.1** (upgraded from 4.2)
 - **UV package manager** for faster dependency management
 - **Vite 6.x** build tool for fast dev server startup and lean production bundles

--- a/frontend/js/App.vue
+++ b/frontend/js/App.vue
@@ -7,8 +7,12 @@
         A lean starter for Django 5, Vue 3, and modern JavaScript tooling.
       </p>
       <div class="actions">
-        <a href="https://vuejs.org/" target="_blank" rel="noreferrer">Vue docs</a>
-        <a href="https://vite.dev/" target="_blank" rel="noreferrer">Vite docs</a>
+        <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer"
+          >Vue docs</a
+        >
+        <a href="https://vite.dev/" target="_blank" rel="noopener noreferrer"
+          >Vite docs</a
+        >
       </div>
     </section>
   </main>
@@ -89,6 +93,13 @@ h1 {
 }
 
 .actions a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(23, 49, 61, 0.14);
+}
+
+.actions a:focus-visible {
+  outline: 3px solid #0f6779;
+  outline-offset: 2px;
   transform: translateY(-1px);
   box-shadow: 0 10px 24px rgba(23, 49, 61, 0.14);
 }

--- a/frontend/js/App.vue
+++ b/frontend/js/App.vue
@@ -1,60 +1,95 @@
 <template>
-  <div id="app">
-    <img src="../img/logo.png">
-    <h1>{{ msg }}</h1>
-    <h2>Essential Links</h2>
-    <ul>
-      <li><a href="https://vuejs.org" target="_blank">Core Docs</a></li>
-      <li><a href="https://forum.vuejs.org" target="_blank">Forum</a></li>
-      <li><a href="https://gitter.im/vuejs/vue" target="_blank">Gitter Chat</a></li>
-      <li><a href="https://twitter.com/vuejs" target="_blank">Twitter</a></li>
-    </ul>
-    <h2>Ecosystem</h2>
-    <ul>
-      <li><a href="http://router.vuejs.org/" target="_blank">vue-router</a></li>
-      <li><a href="http://vuex.vuejs.org/" target="_blank">vuex</a></li>
-      <li><a href="http://vue-loader.vuejs.org/" target="_blank">vue-loader</a></li>
-      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank">awesome-vue</a></li>
-    </ul>
-  </div>
+  <main class="app-shell">
+    <section class="hero">
+      <p class="eyebrow">Django + Vue</p>
+      <h1>Build with Vite, not webpack.</h1>
+      <p class="lede">
+        A lean starter for Django 5, Vue 3, and modern JavaScript tooling.
+      </p>
+      <div class="actions">
+        <a href="https://vuejs.org/" target="_blank" rel="noreferrer">Vue docs</a>
+        <a href="https://vite.dev/" target="_blank" rel="noreferrer">Vite docs</a>
+      </div>
+    </section>
+  </main>
 </template>
 
-<script>
-export default {
-  name: 'app',
-  data () {
-    return {
-      msg: 'Welcome to Your Vue.js App'
-    }
-  }
-}
-</script>
-
-<style>
-#app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  margin-top: 60px;
+<style scoped>
+:global(body) {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(82, 183, 136, 0.16), transparent 42%),
+    linear-gradient(180deg, #f7fafc 0%, #edf4f7 100%);
+  color: #17313d;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
 }
 
-h1, h2 {
-  font-weight: normal;
+.app-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
 }
 
-ul {
-  list-style-type: none;
-  padding: 0;
+.hero {
+  width: min(100%, 44rem);
+  padding: clamp(2rem, 4vw, 4rem);
+  border: 1px solid rgba(23, 49, 61, 0.08);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 20px 60px rgba(23, 49, 61, 0.12);
+  backdrop-filter: blur(14px);
 }
 
-li {
-  display: inline-block;
-  margin: 0 10px;
+.eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #4b7a86;
 }
 
-a {
-  color: #42b983;
+h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+
+.lede {
+  margin: 1.25rem 0 0;
+  max-width: 34rem;
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: rgba(23, 49, 61, 0.82);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 10rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  color: #17313d;
+  background: #d8f0e6;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.actions a:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(23, 49, 61, 0.14);
 }
 </style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,8 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import path from 'path'
 
 export default defineConfig({
   plugins: [vue()],
-  
-  // Entry point
   build: {
     outDir: 'frontend/dist',
     emptyOutDir: true,
@@ -13,39 +10,22 @@ export default defineConfig({
     rollupOptions: {
       input: 'frontend/js/main.js',
       output: {
-        // Keep similar naming convention for Django integration
         entryFileNames: '[name]-[hash].js',
         chunkFileNames: '[name]-[hash].js',
         assetFileNames: '[name]-[hash].[ext]'
       }
     }
   },
-
-  // Development server
   server: {
     host: '127.0.0.1',
     port: 3000,
     open: false,
     cors: true
   },
-
-  // Asset handling
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'frontend'),
-      '~': path.resolve(__dirname, 'frontend')
-    }
-  },
-
-  // Public assets
-  publicDir: false, // Don't copy public assets to dist
-  
-  // CSS handling
+  publicDir: false,
   css: {
     devSourcemap: true
   },
-
-  // Define environment variables
   define: {
     __VUE_OPTIONS_API__: true,
     __VUE_PROD_DEVTOOLS__: false


### PR DESCRIPTION
Modernizes the sample app to match the current Vite-based stack and cleans up the starter experience.

Changes:
- Replace the legacy Vue 2 starter content with a compact Vue 3 landing page.
- Remove legacy webpack/Babel wording from the README and align setup instructions with `npm ci`/Makefile usage.
- Simplify the Vite config by removing unused aliases and comments.

Validation:
- `make lint`
- `SECRET_KEY=test-secret DEBUG=1 ALLOWED_HOSTS=localhost,127.0.0.1 .venv/bin/python manage.py test`
- `npm run build`