### PR TITLE
🔒 Remove hardcoded SECRET_KEY from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /app/node_modules
       - /app/.venv
     environment:
-      - SECRET_KEY=dev-secret-key-change-me
+      - SECRET_KEY=${SECRET_KEY}
       - DEBUG=1
       - ALLOWED_HOSTS=localhost,127.0.0.1
       - DJANGO_VITE_DEV_MODE=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /app/node_modules
       - /app/.venv
     environment:
-      - SECRET_KEY=${SECRET_KEY}
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set (e.g., via .env)}
       - DEBUG=1
       - ALLOWED_HOSTS=localhost,127.0.0.1
       - DJANGO_VITE_DEV_MODE=1


### PR DESCRIPTION
🎯 **What:** The `SECRET_KEY` environment variable in `docker-compose.yml` was hardcoded to `dev-secret-key-change-me`.
⚠️ **Risk:** Storing a secret key in source control is a severe security risk. If this file is committed, the secret is exposed to anyone with access to the repository. This could allow attackers to forge session cookies or exploit cryptographic features of the framework.
🛡️ **Solution:** Modified `docker-compose.yml` to use environment variable interpolation (`${SECRET_KEY}`) so that it relies on the external `.env` file instead of defining a sensitive value within the file itself.

---
*PR created automatically by Jules for task [10145049114232004623](https://jules.google.com/task/10145049114232004623) started by @mikebz*