### PR TITLE
🧹 Remove unused template context variable in index view

### DIFF
--- a/backend/views.py
+++ b/backend/views.py
@@ -14,10 +14,7 @@ def index(request: HttpRequest) -> HttpResponse:
         The HTTP response containing the rendered index page.
 
     """
-    context: dict[str, str] = {
-        "data": "value",
-    }
-    return render(request, "index.html", context)
+    return render(request, "index.html")
 
 
 def healthz(_request: HttpRequest) -> JsonResponse:


### PR DESCRIPTION
🎯 **What:** Removed the unused `context` dictionary in the `index` view.
💡 **Why:** Simplifies the code and removes dead code, as the `index.html` template doesn't utilize any variables.
✅ **Verification:** Verified by running `make test`, `make lint` and `make typecheck`, all of which passed, indicating no break in functionality.
✨ **Result:** Improved codebase maintainability without changing behavior.

---
*PR created automatically by Jules for task [10705279001740712688](https://jules.google.com/task/10705279001740712688) started by @mikebz*