### PR TITLE
docs: record the CodeQL configuration-rename trap

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,15 @@ jobs:
       actions: read
       contents: read
 
+    # Each entry here becomes a code scanning configuration keyed by
+    # `<workflow file>:<job id>/<category>`, and the category below is derived
+    # from the language. Renaming a language therefore retires the old
+    # configuration and creates a new one: the default branch keeps expecting
+    # the retired name, so every pull request gets a neutral "configurations
+    # not found" results check until the stale one is deleted under
+    # Security > Code scanning > Tool status (or ages out on its own).
+    # Treat these values as an interface - changing one is a migration, not a
+    # rename.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Switching the matrix language from `javascript` to `javascript-typescript`
retired the `analyze/language:javascript` code scanning configuration and
created a new one. master still expects the retired configuration, so the
CodeQL results check on pull requests reports "2 configurations not found"
and goes neutral until that stale entry is deleted or expires.

Nothing in the workflow can undo that from here - any further category
change would only orphan another configuration - so document the coupling
between the matrix values and the configuration keys instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PVdTTqLYbyCU9dFQZAZWVt