### PR TITLE
🧹 fix CodeQL missing configuration error in CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'python' ]
+        language: [ 'javascript', 'python' ]
 
     steps:
     - name: Checkout repository
@@ -57,6 +57,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.3
-      with:
-        # Keeps each matrix leg's results distinct instead of overwriting.
-        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
🎯 **What:**
Revert the 'javascript-typescript' language matrix value back to 'javascript' and remove the manually specified `category` from the CodeQL analyze step in `.github/workflows/codeql-analysis.yml`.

💡 **Why:**
A previous commit attempted to update the CodeQL configuration by explicitly setting a custom `category` string and updating the language to `'javascript-typescript'`. However, CodeQL uses a combination of the workflow name, job ID, and category to track analysis results over time. Changing these inputs created new analysis configurations and severed the link to the existing analyses on the `master` branch. As a result, CodeQL blocked pull requests with a "configurations not found" error because it was looking for the historical runs. Reverting to the old matrix name (`javascript` is still fully supported) and allowing the action to auto-generate the category restores tracking continuity.

✅ **Verification:**
Verified by ensuring the `.github/workflows/codeql-analysis.yml` diff reverts precisely the problematic modifications to `matrix` and `category` without breaking syntax. Backend tests run via `make test` are passing (which required building frontend assets via `make frontend-install` and `make frontend-build`).

✨ **Result:**
The GitHub Actions Code Scanning check will correctly find its baseline analyses and the CI pipeline will pass on PRs.

---
*PR created automatically by Jules for task [4344678513343853214](https://jules.google.com/task/4344678513343853214) started by @mikebz*