### PR TITLE
Load .env in settings, with the environment taking precedence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,13 @@
+# Copy to .env (`make setup` does it for you) and edit. .env is git-ignored.
+#
+# Django loads .env at startup, and anything already set in the environment
+# wins over this file. Write plain KEY=value lines: comments go on their own
+# line, and quotes are optional.
+#
+# README.md documents what every variable does.
+
+# Development placeholder. Generate a real one for any deployment, e.g.
+# python -c "import secrets; print(secrets.token_urlsafe(64))"
 SECRET_KEY=replace-me
 DEBUG=1
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,16 +94,21 @@ the reasoning comes from an external source.
 - `mypy` runs in `strict` mode with the `django-stubs` plugin. **Every function
   needs full type annotations**, including `-> None`, and module-level settings
   carry explicit annotations too. Migrations are excluded. The plugin imports
-  `djangovue.settings`, so `make typecheck` only works with the environment the
-  `Makefile` loads from `.env.example` — run it through `make`, not bare `mypy`.
+  `djangovue.settings`, which needs a `SECRET_KEY` — run `make typecheck`
+  rather than bare `mypy`, so the `.env` file gets created first.
 - **No function name may exceed 50 characters.** This applies to test functions
   too — if a name does not fit, the test is usually covering too much.
 - Docstrings are Google-style with `Args:`/`Returns:`/`Raises:` sections, and
   every module has one. Match that, even though no linter enforces it.
-- The env helpers in `djangovue/settings.py` (`get_env_bool`, `get_env_list`,
+- The env helpers in `djangovue/utils.py` (`get_env_bool`, `get_env_list`,
   `get_env_int`) take an optional `environ` mapping so they can be tested
   without mutating `os.environ`. Read configuration through them instead of
   touching `os.environ` inline, and keep new config readers in that shape.
+- Configuration comes from `.env`, which `djangovue/settings.py` loads at import
+  time via `load_env_file`. **Real environment variables always win over the
+  file** — that is what lets Docker, Compose, CI, and the `Makefile` override a
+  single key. A new setting goes in `.env.example` and is read through the env
+  helpers; nothing should re-implement the loading.
 - Responses are served under a Content Security Policy built by
   `build_csp_policy` in `djangovue/settings.py`. Anything that loads an asset
   from a new origin, or adds an inline script or style, has to be reflected

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,40 +22,42 @@ RUN npm run build
 # Python application stage
 FROM python:3.14-slim
 
-# Set environment variables
+# PATH puts the project virtualenv first, so `python` and `gunicorn` below are
+# the installed ones and nothing has to resolve dependencies at container start.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    UV_SYSTEM_PYTHON=1
+    PATH="/app/.venv/bin:$PATH"
 
-# Install system dependencies
+# curl backs the HEALTHCHECK below. No compiler is installed: every Python
+# dependency ships a pure-Python wheel.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl \
-        build-essential \
+    && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install UV
-RUN pip install uv
+RUN pip install --no-cache-dir uv
 
 # Set work directory
 WORKDIR /app
 
-# Copy Python dependency files
+# Third-party dependencies resolve from the lock file alone, so this layer is
+# reused across every source-only change. The project itself is installed by the
+# second sync, once its source is in place.
 COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
 
-# Copy project files required to build/install the local package
 COPY . .
-
-# Install Python dependencies
 RUN uv sync --frozen --no-dev
 
 # Copy built frontend from previous stage
 COPY --from=frontend-builder /app/frontend/dist/ ./frontend/dist/
 
-# Collect static files
-# Use a safe dummy key via ARG to avoid hardcoding secrets in the RUN command
+# Collect static files. Settings are imported here, so the two required
+# variables are supplied for this command only - .dockerignore keeps .env out of
+# the image, and runtime configuration comes from the container environment.
 ARG BUILD_DUMMY_KEY=dummy-secret-key-for-build
-RUN SECRET_KEY=${BUILD_DUMMY_KEY} DEBUG=1 ALLOWED_HOSTS=localhost uv run python manage.py collectstatic --noinput
+RUN SECRET_KEY=${BUILD_DUMMY_KEY} DEBUG=1 ALLOWED_HOSTS=localhost \
+    python manage.py collectstatic --noinput
 
 # Create non-root user
 RUN adduser --disabled-password --gecos '' appuser && \
@@ -70,4 +72,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/healthz || exit 1
 
 # Run application
-CMD ["uv", "run", "gunicorn", "djangovue.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--timeout", "60"]
+CMD ["gunicorn", "djangovue.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "3", "--timeout", "60"]

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,19 @@
 .DEFAULT_GOAL := help
 .NOTPARALLEL:
 
-# .env.example provides defaults; a local .env overrides individual keys.
-ENV_FILES := .env.example $(wildcard .env)
--include $(ENV_FILES)
+# Django loads .env itself (see djangovue/settings.py), so make only has to
+# make sure the file exists. Variables exported here - or by CI, docker run, or
+# the shell - still win over it, which is how the DJANGO_VITE_DEV_MODE override
+# below works.
+.env:
+	cp .env.example $@
 
-ENV_KEYS := $(shell sed -nE 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*/\1/p' $(ENV_FILES) | sort -u)
-export $(ENV_KEYS)
-
-# Targets that shell out to uv all depend on the guard below. `run` and `e2e` name
-# it in their own rules instead, so it is checked before the frontend is built.
+# Targets that shell out to uv all depend on the guards below. `run` and `e2e`
+# name them in their own rules instead, so they are checked before the frontend
+# is built.
 UV_TARGETS := install migrate makemigrations shell lint lint-fix format \
               check typecheck test status collectstatic superuser
-$(UV_TARGETS): ensure-uv
+$(UV_TARGETS): ensure-uv .env
 
 # Targets that must render templates against the built manifest rather than
 # the Vite dev server. Prerequisites inherit this, so frontend-build sees it too.
@@ -28,19 +29,19 @@ run e2e check test: export DJANGO_VITE_DEV_MODE := 0
 
 help: ## Show this help message
 	@printf "Django + Vue commands\n\n"
-	@grep -E '^[a-zA-Z_-]+:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  %-18s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*## ' $(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*## "}; {printf "  %-18s %s\n", $$1, $$2}'
 
 ensure-uv:
 	@command -v uv >/dev/null 2>&1 || { echo "Install uv: https://docs.astral.sh/uv/getting-started/installation/" >&2; exit 1; }
 
 # Setup
-setup: install frontend-install migrate ## Initial project setup
+setup: .env install frontend-install migrate ## Create .env, install dependencies, migrate
 
 install: ## Install Python dependencies
 	uv sync --extra dev
 
 # Django
-run: ensure-uv frontend-build ## Start Django with built frontend assets on a single port
+run: ensure-uv .env frontend-build ## Start Django with built frontend assets on a single port
 	@echo "Django binds to 0.0.0.0:8000."
 	@echo "In a dev container or Codespaces, open the forwarded port URL from the Ports tab."
 	@echo "From inside the container, the app is available at http://127.0.0.1:8000/."
@@ -78,7 +79,7 @@ check: ## Run Django system checks
 test: ## Run Django tests
 	uv run manage test
 
-e2e: ensure-uv frontend-build ## Run end-to-end checks (template render + server boot)
+e2e: ensure-uv .env frontend-build ## Run end-to-end checks (template render + server boot)
 	uv run manage migrate
 	uv run python scripts/e2e_template_check.py
 	./scripts/e2e_server_smoke.sh
@@ -100,7 +101,7 @@ typecheck: ## Run static type checking with mypy
 
 # Builds the frontend up front: `check` and `test` render templates against the
 # manifest, so on a clean checkout they fail without it (CI builds separately).
-verify: ensure-uv frontend-build ## Run lint, checks, tests, and e2e used in CI
+verify: ensure-uv .env frontend-build ## Run lint, checks, tests, and e2e used in CI
 	$(MAKE) lint typecheck check test e2e
 
 # Frontend
@@ -130,11 +131,14 @@ prod-build: install frontend-build collectstatic ## Build for production
 docker-build: ## Build Docker image
 	docker build -t djangovue:latest .
 
-docker-run: docker-build ## Build and run Docker container
-	docker run --rm -p 8000:8000 djangovue:latest
+# The image carries no .env (.dockerignore keeps it out), so configuration is
+# passed in. DJANGO_VITE_DEV_MODE is forced off because the image serves the
+# assets it built - the -e flag beating the file is the precedence rule at work.
+docker-run: .env docker-build ## Build and run Docker container
+	docker run --rm --env-file .env -e DJANGO_VITE_DEV_MODE=0 -p 8000:8000 djangovue:latest
 
-docker-dev: ## Run development environment in Docker
-	docker-compose up --build
+docker-dev: .env ## Run development environment in Docker
+	docker compose up --build
 
 # Cleanup
 clean: ## Clean up generated files

--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ uv sync --extra dev
 4. Configure environment variables
 ```bash
 cp .env.example .env
-set -a
-source .env
-set +a
 ```
 
-The Makefile always loads `.env.example` defaults and then applies `.env`
-overrides when present, exporting those env-driven Django/Vite settings for
-local commands.
+Django loads `.env` from the project root on startup, so `uv run python
+manage.py ...`, Gunicorn, and the test suite all see the same configuration —
+nothing has to be exported into your shell. Any `make` target that starts
+Django creates `.env` from `.env.example` if it is missing, so `make setup` is
+enough on a fresh checkout.
 
 5. Install JavaScript dependencies and build
 ```bash
@@ -121,6 +120,20 @@ uv sync                               # Install dependencies
 
 ## Environment Variables
 
+Configuration is read from the process environment, with `.env` in the project
+root filling in whatever the environment does not already define:
+
+1. real environment variables — a shell `export`, `docker run -e`, a Compose
+   `environment:` entry, or a CI secret;
+2. `.env` — your local, git-ignored file, copied from `.env.example`;
+3. the defaults in `djangovue/settings.py`, except for the two required
+   variables below.
+
+Environment variables always win, so a deployment can override a single key
+without touching the file — and a deployment that passes every variable in
+needs no `.env` at all. `.env` is excluded from the Docker image for the same
+reason; `make docker-run` passes it in with `--env-file`.
+
 Required:
 - `SECRET_KEY`: Django secret key.
 - `ALLOWED_HOSTS`: Comma-separated hostnames allowed when `DEBUG=0`.
@@ -190,10 +203,17 @@ make docker-run
 make docker-dev
 
 # Or manually:
-docker-compose up --build
+docker compose up --build
 ```
 
-The production container now serves Django through Gunicorn and exposes a health endpoint at `/healthz`.
+The production container serves Django through Gunicorn and exposes a health
+endpoint at `/healthz`. It ships without a `.env` file, so configuration is
+passed in at run time — `make docker-run` forwards your local one with
+`--env-file .env`, and any `-e` flag overrides a single key from it.
+
+The Compose stack is for development: it mounts the working tree, runs
+`runserver` so edits reload, reads the same `.env`, and points Django at the
+Vite dev server running in the `frontend` service.
 
 ### Manual Testing
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -5,6 +5,8 @@ Author: Mike Borozdin (mikebz@)
 
 import importlib
 import os
+import tempfile
+from pathlib import Path
 from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
@@ -23,15 +25,128 @@ class SettingsModuleTest(SimpleTestCase):
         WHEN: The settings module is evaluated
         THEN: It should raise ImproperlyConfigured
         """
-        # We use mock.patch.dict to clear the environment for testing
-        with mock.patch.dict(os.environ, clear=True):
-            with self.assertRaisesMessage(
-                ImproperlyConfigured, "SECRET_KEY environment variable must be set"
-            ):
-                importlib.reload(project_settings)
+        # The settings module loads .env before reading SECRET_KEY, so the
+        # loader is stubbed out too - otherwise a developer's .env would
+        # repopulate the environment this test just cleared.
+        with mock.patch.object(utils, "load_env_file", return_value={}):
+            with mock.patch.dict(os.environ, clear=True):
+                with self.assertRaisesMessage(
+                    ImproperlyConfigured, "SECRET_KEY environment variable must be set"
+                ):
+                    importlib.reload(project_settings)
 
         # Reload settings again with the original environment to restore state
         importlib.reload(project_settings)
+
+
+class EnvFileParsingTest(SimpleTestCase):
+    """Test the .env file parser that feeds project configuration."""
+
+    def test_parser_skips_comments_and_blanks(self) -> None:
+        """Intent: a .env file stays readable with comments and spacing.
+
+        Steps:
+            1. Parse a file containing a comment line, a blank line, and one
+               assignment.
+
+        Verification:
+            Only the assignment survives.
+        """
+        parsed = utils.parse_env_file("# a comment\n\nDEBUG=1\n")
+        self.assertEqual(parsed, {"DEBUG": "1"})
+
+    def test_parser_strips_export_and_quotes(self) -> None:
+        """Intent: a .env file that is also shell-sourceable parses the same.
+
+        Steps:
+            1. Parse lines using an `export ` prefix and quoted values.
+
+        Verification:
+            The prefix and the matching quotes are removed from the result.
+        """
+        parsed = utils.parse_env_file("export HOSTS='a,b'\nKEY=\"secret\"\n")
+        self.assertEqual(parsed, {"HOSTS": "a,b", "KEY": "secret"})
+
+    def test_parser_keeps_equals_in_value(self) -> None:
+        """Intent: URL-shaped settings survive parsing intact.
+
+        Steps:
+            1. Parse a value that itself contains "=".
+
+        Verification:
+            Only the first "=" separates name from value.
+        """
+        parsed = utils.parse_env_file("DATABASE_URL=postgres://u:p@h/db?x=1")
+        self.assertEqual(parsed, {"DATABASE_URL": "postgres://u:p@h/db?x=1"})
+
+
+class EnvFileLoadingTest(SimpleTestCase):
+    """Test how a .env file is applied to the process environment."""
+
+    def _write_env(self, contents: str) -> Path:
+        """Write a .env file into a temporary directory for one test.
+
+        Args:
+            contents: The file contents to write.
+
+        Returns:
+            The path to the written file.
+
+        """
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / ".env"
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_load_sets_undefined_variables(self) -> None:
+        """Intent: .env supplies configuration the environment lacks.
+
+        Steps:
+            1. Write a .env file defining DEBUG.
+            2. Load it into an environment that does not define DEBUG.
+
+        Verification:
+            The value from the file is applied and reported as applied.
+        """
+        environ: dict[str, str] = {}
+        applied = utils.load_env_file(self._write_env("DEBUG=1\n"), environ=environ)
+        self.assertEqual(environ, {"DEBUG": "1"})
+        self.assertEqual(applied, {"DEBUG": "1"})
+
+    def test_environment_wins_over_env_file(self) -> None:
+        """Intent: a real environment variable overrides the .env file.
+
+        Steps:
+            1. Write a .env file defining DEBUG and ALLOWED_HOSTS.
+            2. Load it into an environment that already defines DEBUG.
+
+        Verification:
+            DEBUG keeps the value it was given, ALLOWED_HOSTS comes from the
+            file, and only the latter is reported as applied.
+        """
+        environ = {"DEBUG": "0"}
+        applied = utils.load_env_file(
+            self._write_env("DEBUG=1\nALLOWED_HOSTS=example.com\n"),
+            environ=environ,
+        )
+        self.assertEqual(environ["DEBUG"], "0")
+        self.assertEqual(environ["ALLOWED_HOSTS"], "example.com")
+        self.assertEqual(applied, {"ALLOWED_HOSTS": "example.com"})
+
+    def test_missing_env_file_is_not_an_error(self) -> None:
+        """Intent: deployments configured purely by environment need no file.
+
+        Steps:
+            1. Load a path that does not exist.
+
+        Verification:
+            Nothing is applied and no exception is raised.
+        """
+        environ = {"DEBUG": "0"}
+        applied = utils.load_env_file(Path("no-such-directory/.env"), environ=environ)
+        self.assertEqual(applied, {})
+        self.assertEqual(environ, {"DEBUG": "0"})
 
 
 class SettingsHelpersTest(SimpleTestCase):

--- a/djangovue/settings.py
+++ b/djangovue/settings.py
@@ -22,11 +22,19 @@ from djangovue.utils import (
     get_env_int,
     get_env_list,
     get_env_str,
+    load_env_file,
     validate_hsts_preload,
 )
 
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR: Path = Path(__file__).resolve().parent.parent
+
+# Local configuration comes from .env, copied from .env.example by `make setup`
+# and never committed. Loading it here rather than in a task runner is what
+# makes `uv run manage ...`, gunicorn, and the e2e scripts all see the same
+# configuration. Real environment variables are left untouched, so a container
+# or a CI job overrides individual keys without a file at all.
+load_env_file(BASE_DIR / ".env")
 
 
 # Quick-start development settings - unsuitable for production

--- a/djangovue/utils.py
+++ b/djangovue/utils.py
@@ -3,10 +3,86 @@ Author: Mike Borozdin (mikebz@)
 """
 
 import os
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
+from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.csp import CSP
+
+
+def parse_env_file(text: str) -> dict[str, str]:
+    """Parse the contents of a .env file into a mapping.
+
+    Recognizes `KEY=value` lines with an optional `export ` prefix and optional
+    matching quotes around the value. Blank lines and lines starting with `#`
+    are skipped; a `#` anywhere else belongs to the value, so comments go on
+    their own line. Everything after the first `=` is the value, which is what
+    makes `DATABASE_URL` and other URL-shaped settings survive the round trip.
+
+    Args:
+        text: The raw contents of a .env file.
+
+    Returns:
+        A mapping of variable name to value, in file order.
+
+    Examples:
+        >>> parse_env_file("# comment\\nDEBUG=1\\n\\nexport HOSTS='a,b'\\n")
+        {'DEBUG': '1', 'HOSTS': 'a,b'}
+        >>> parse_env_file("DATABASE_URL=sqlite:///db.sqlite3")
+        {'DATABASE_URL': 'sqlite:///db.sqlite3'}
+
+    """
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        name, _, value = stripped.partition("=")
+        name = name.removeprefix("export ").strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        if name:
+            values[name] = value
+    return values
+
+
+def load_env_file(
+    path: Path | str,
+    *,
+    environ: MutableMapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Apply a .env file to the environment without overwriting it.
+
+    A variable that is already set wins over the file, so a shell export, a
+    `docker run -e` flag, or a compose `environment:` entry overrides a single
+    key without anyone editing .env. A missing file is not an error: the file
+    is a convenience for local development, and deployments that pass real
+    environment variables never need one.
+
+    Args:
+        path: Path to the .env file.
+        environ: Optional mapping to update instead of `os.environ`.
+
+    Returns:
+        The variables actually applied - those the environment did not
+        already define.
+
+    Examples:
+        >>> load_env_file("does-not-exist.env", environ={})
+        {}
+
+    """
+    env = os.environ if environ is None else environ
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    applied = {
+        name: value for name, value in parse_env_file(text).items() if name not in env
+    }
+    env.update(applied)
+    return applied
 
 
 def get_env_bool(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
-version: '3.8'
-
+# Development stack: Django with auto-reload plus the Vite dev server.
+# `make docker-dev` creates .env from .env.example first if it is missing.
 services:
   web:
     build: .
@@ -9,17 +9,26 @@ services:
       - .:/app
       - /app/node_modules
       - /app/.venv
+    # The same .env the host uses. `environment:` below holds only what this
+    # stack needs differently, and it wins over the file - both in Compose and
+    # inside Django, which skips any variable the environment already defines.
+    env_file:
+      - path: .env
+        required: false
     environment:
-      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set (e.g., via .env)}
-      - DEBUG=1
-      - ALLOWED_HOSTS=localhost,127.0.0.1
-      - DJANGO_VITE_DEV_MODE=1
-      - DJANGO_VITE_DEV_SERVER_HOST=frontend
-      - DJANGO_VITE_DEV_SERVER_PORT=3000
-      - DJANGO_SETTINGS_MODULE=djangovue.settings
+      DEBUG: "1"
+      ALLOWED_HOSTS: localhost,127.0.0.1
+      # Assets come from the frontend service, reachable under its name.
+      DJANGO_VITE_DEV_MODE: "1"
+      DJANGO_VITE_DEV_SERVER_HOST: frontend
+      DJANGO_VITE_DEV_SERVER_PORT: "3000"
+    # runserver rather than gunicorn: the bind mount above is only worth having
+    # with a reloader watching it.
     command: >
-      sh -c "uv run python manage.py migrate &&
-             uv run gunicorn djangovue.wsgi:application --bind 0.0.0.0:8000 --workers 3 --timeout 60"
+      sh -c "python manage.py migrate &&
+             python manage.py runserver 0.0.0.0:8000"
+    depends_on:
+      - frontend
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
       interval: 30s
@@ -37,4 +46,4 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NODE_ENV=development
+      NODE_ENV: development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,6 @@ files = ["backend", "djangovue", "manage.py", "scripts/e2e_template_check.py"]
 plugins = ["mypy_django_plugin.main"]
 
 [tool.django-stubs]
-# The plugin imports these settings, so `make typecheck` must run with the
-# environment from .env.example loaded - the Makefile does that for every target.
+# The plugin imports these settings, which read .env at import time, so
+# `make typecheck` needs that file - the Makefile creates it from .env.example.
 django_settings_module = "djangovue.settings"


### PR DESCRIPTION
Behavioral change.

Configuration was only reachable through `make`, which sourced .env.example
into its own environment and exported it. Anything started another way -
`uv run python manage.py ...`, gunicorn, the e2e scripts - saw no
configuration at all, and because make variables beat the environment, an
exported SECRET_KEY was silently ignored in favour of the placeholder.

Django now loads .env itself at settings import, so every entry point sees the
same configuration. Variables already present in the environment are left
alone, which makes the precedence explicit: real environment variables, then
.env, then the defaults in settings.py. A missing .env is not an error, so a
deployment that passes everything in as environment variables needs no file.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4uFd8Y7d48qjViR79oGqT