### PR TITLE
🧪 [add tests for get_env_bool with falsy values]

### DIFF
--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -161,6 +161,13 @@ class SettingsHelpersTest(SimpleTestCase):
         environ = {"DEBUG": "true"}
         self.assertTrue(utils.get_env_bool("DEBUG", environ=environ))
 
+    def test_get_env_bool_parses_falsy_values(self) -> None:
+        """Parse strings not in the truthy set to False."""
+        for value in ["0", "false", "f", "no", "n", "off", "anything_else"]:
+            with self.subTest(value=value):
+                environ = {"DEBUG": value}
+                self.assertFalse(utils.get_env_bool("DEBUG", environ=environ))
+
     def test_get_env_list_splits_values(self) -> None:
         """Split comma-separated list values and trim whitespace."""
         environ = {"ALLOWED_HOSTS": "example.com, api.example.com"}


### PR DESCRIPTION
🎯 **What:** Added tests to cover the case where `get_env_bool` is provided with falsy values, which is currently a gap in the test suite.
📊 **Coverage:** Explicitly covers edge case string values "0", "false", "f", "no", "n", "off" and an arbitrary unrecognised string to ensure they parse correctly to False.
✨ **Result:** Test coverage for `get_env_bool` is improved, establishing a clear safety net that correctly handles various combinations of False representations in the environment.

---
*PR created automatically by Jules for task [11963160450253949206](https://jules.google.com/task/11963160450253949206) started by @mikebz*