### PR TITLE
Add ARCHITECTURE.md and refactor documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ make frontend-build && make verify
 `make frontend-build` first is not optional. `make verify` renders
 `index.html`, which resolves assets through
 `frontend/dist/.vite/manifest.json`. On a fresh checkout that file does not
-exist and 9 of the 19 tests fail with `DjangoViteAssetNotFoundError` — a
+exist and 12 of the 43 tests fail with `DjangoViteAssetNotFoundError` — a
 failure that has nothing to do with your change. `make verify` itself does not
 build the frontend; CI does it in a separate step.
 
@@ -101,18 +101,19 @@ the reasoning comes from an external source.
 - Docstrings are Google-style with `Args:`/`Returns:`/`Raises:` sections, and
   every module has one. Match that, even though no linter enforces it.
 - The env helpers in `djangovue/utils.py` (`get_env_bool`, `get_env_list`,
-  `get_env_int`) take an optional `environ` mapping so they can be tested
-  without mutating `os.environ`. Read configuration through them instead of
-  touching `os.environ` inline, and keep new config readers in that shape.
+  `get_env_str`, `get_env_int`) take an optional `environ` mapping so they can
+  be tested without mutating `os.environ`. Read configuration through them
+  instead of touching `os.environ` inline, and keep new config readers in that
+  shape.
 - Configuration comes from `.env`, which `djangovue/settings.py` loads at import
-  time via `load_env_file`. **Real environment variables always win over the
-  file** — that is what lets Docker, Compose, CI, and the `Makefile` override a
-  single key. A new setting goes in `.env.example` and is read through the env
+  time via `load_env_file` from `djangovue/utils.py`. **Real environment
+  variables always win over the file** — that is what lets Docker, Compose, CI,
+  and the `Makefile` override a single key. A new setting goes in `.env.example` and is read through the env
   helpers; nothing should re-implement the loading.
 - Responses are served under a Content Security Policy built by
-  `build_csp_policy` in `djangovue/settings.py`. Anything that loads an asset
-  from a new origin, or adds an inline script or style, has to be reflected
-  there — reach for `{{ csp_nonce }}` before reaching for `'unsafe-inline'`.
+  `build_csp_policy` in `djangovue/utils.py` and applied as `SECURE_CSP` in
+  `djangovue/settings.py`. Anything that loads an asset from a new origin, or
+  adds an inline script or style, has to be reflected there — reach for `{{ csp_nonce }}` before reaching for `'unsafe-inline'`.
 - Broader style guidance follows *Effective Python* — see
   https://github.com/SigmaQuan/Better-Python-59-Ways.
 
@@ -126,7 +127,12 @@ the reasoning comes from an external source.
 
 **Tests**
 
-- Python tests live in `backend/tests.py`.
+- Python tests live in the `backend/tests/` package, split by subject:
+  `test_views.py` (views, routing, Vite integration, `/healthz`),
+  `test_settings.py` (`.env` parsing and loading, the env helpers), and
+  `test_security.py` (response headers, CSP construction, HSTS validation).
+  Add a test to the module that matches its subject; add a new
+  `test_<subject>.py` rather than letting one grow unfocused.
 - **Prefer test functions over test classes.** Reach for a class only when the
   test genuinely needs one — shared fixture setup that cannot be expressed as a
   plain helper, or a Django facility that requires a `TestCase` subclass.
@@ -152,6 +158,11 @@ the reasoning comes from an external source.
   lists what the test does, in order. *Verification* states exactly what is
   asserted. A test whose intent cannot be written in one sentence is testing
   more than one thing — split it.
+
+  `backend/tests/test_views.py` still carries an older `GIVEN:`/`WHEN:`/`THEN:`
+  form. That style is retired: write new tests with the outline above, and
+  convert a docstring you are already editing. Do not convert the rest as a
+  drive-by — a whole-file conversion is its own structural commit.
 
 - Settings-related tests reload `djangovue.settings` under `mock.patch.dict` —
   reuse that pattern instead of asserting against process state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ documentation: for project structure, setup, and environment variables see
 `README.md`; for the list of available commands run `make help`, since the
 `Makefile` is the source of truth and CI calls the same targets.
 
+Keep it that way when you edit this file. This file carries **rules** — what to
+do and what not to do. When a rule needs architectural context, link to the
+section of `README.md` that explains it instead of restating the explanation
+here. A description copied into two files drifts in one of them.
+
 ## Plan large changes before writing code
 
 A change is **large** if any of these are true:
@@ -105,17 +110,14 @@ the reasoning comes from an external source.
   be tested without mutating `os.environ`. Read configuration through them
   instead of touching `os.environ` inline, and keep new config readers in that
   shape.
-- Configuration comes from `.env`, which `djangovue/settings.py` loads at import
-  time via `load_env_file` from `djangovue/utils.py`. **Real environment
-  variables always win over the file** — that is what lets Docker, Compose, CI,
-  and the `Makefile` override a single key. A new setting goes in
-  `.env.example` and is read through the env helpers; nothing should
-  re-implement the loading.
-- Responses are served under a Content Security Policy built by
-  `build_csp_policy` in `djangovue/utils.py` and applied as `SECURE_CSP` in
-  `djangovue/settings.py`. Anything that loads an asset from a new origin, or
-  adds an inline script or style, has to be reflected there — reach for
-  `{{ csp_nonce }}` before reaching for `'unsafe-inline'`.
+- Adding a setting: put it in `.env.example` with a placeholder and read it
+  through the env helpers. Never re-implement the loading or the
+  environment-beats-file precedence — see *Environment Variables* in
+  `README.md` for how that layering works.
+- Changing what the page loads: anything served from a new origin, or any
+  inline script or style, has to be reflected in the Content Security Policy,
+  and `{{ csp_nonce }}` comes before `'unsafe-inline'`. See *Content Security
+  Policy* in `README.md` for what the policy already allows.
 - Broader style guidance follows *Effective Python* — see
   https://github.com/SigmaQuan/Better-Python-59-Ways.
 
@@ -129,12 +131,9 @@ the reasoning comes from an external source.
 
 **Tests**
 
-- Python tests live in the `backend/tests/` package, split by subject:
-  `test_views.py` (views, routing, Vite integration, `/healthz`),
-  `test_settings.py` (`.env` parsing and loading, the env helpers), and
-  `test_security.py` (response headers, CSP construction, HSTS validation).
-  Add a test to the module that matches its subject; add a new
-  `test_<subject>.py` rather than letting one grow unfocused.
+- Python tests live in the `backend/tests/` package, one `test_<subject>.py`
+  per subject. Add a test to the module whose subject it matches, or start a
+  new module — do not let one grow into a catch-all.
 - **Prefer test functions over test classes.** Reach for a class only when the
   test genuinely needs one — shared fixture setup that cannot be expressed as a
   plain helper, or a Django facility that requires a `TestCase` subclass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,19 @@ making changes.
 This is the **only** agent instruction file in the repository. There is no
 second copy under `.github/`, no per-tool variant, and no nested override — if a
 rule matters, it goes here. This file also does not duplicate other
-documentation: for project structure, setup, and environment variables see
-`README.md`; for the list of available commands run `make help`, since the
-`Makefile` is the source of truth and CI calls the same targets.
+documentation:
+
+- setup, environment variables, and deployment — `README.md`
+- how the code fits together, and where a thing lives — `ARCHITECTURE.md`
+- the list of available commands — `make help`, since the `Makefile` is the
+  source of truth and CI calls the same targets
 
 Keep it that way when you edit this file. This file carries **rules** — what to
-do and what not to do. When a rule needs architectural context, link to the
-section of `README.md` that explains it instead of restating the explanation
-here. A description copied into two files drifts in one of them.
+do and what not to do. It does not name individual functions, count tests, or
+explain how a subsystem works; that belongs in `ARCHITECTURE.md`, where one
+change updates one file. A description copied into two files drifts in one of
+them, and a rule that recites implementation detail goes stale every time the
+implementation moves.
 
 ## Plan large changes before writing code
 
@@ -44,12 +49,11 @@ tell you whether it works — that round trip is what this rule exists to avoid.
 make frontend-build && make verify
 ```
 
-`make frontend-build` first is not optional. `make verify` renders
-`index.html`, which resolves assets through
-`frontend/dist/.vite/manifest.json`. On a fresh checkout that file does not
-exist and 12 of the 43 tests fail with `DjangoViteAssetNotFoundError` — a
-failure that has nothing to do with your change. `make verify` itself does not
-build the frontend; CI does it in a separate step.
+`make frontend-build` first is not optional. Several checks render the Django
+template, which cannot resolve frontend assets until the frontend has been
+built — on a clean checkout they fail for that reason alone, with nothing wrong
+in your change. If you hit asset-resolution failures, you skipped the build;
+see *Frontend integration* in `ARCHITECTURE.md`. Do not "fix" them.
 
 A change is done when `make frontend-build && make verify` passes from a clean
 tree. Report the result honestly: never describe a partial run as a pass, and
@@ -98,34 +102,31 @@ the reasoning comes from an external source.
   than hand-aligning code.
 - `mypy` runs in `strict` mode with the `django-stubs` plugin. **Every function
   needs full type annotations**, including `-> None`, and module-level settings
-  carry explicit annotations too. Migrations are excluded. The plugin imports
-  `djangovue.settings`, which needs a `SECRET_KEY` — run `make typecheck`
-  rather than bare `mypy`, so the `.env` file gets created first.
+  carry explicit annotations too. Migrations are excluded. Run `make typecheck`
+  rather than bare `mypy` — the target prepares the environment the plugin
+  needs to import settings.
 - **No function name may exceed 50 characters.** This applies to test functions
   too — if a name does not fit, the test is usually covering too much.
 - Docstrings are Google-style with `Args:`/`Returns:`/`Raises:` sections, and
   every module has one. Match that, even though no linter enforces it.
-- The env helpers in `djangovue/utils.py` (`get_env_bool`, `get_env_list`,
-  `get_env_str`, `get_env_int`) take an optional `environ` mapping so they can
-  be tested without mutating `os.environ`. Read configuration through them
-  instead of touching `os.environ` inline, and keep new config readers in that
-  shape.
+- Read configuration through the env helpers in `djangovue/utils.py`, never by
+  touching `os.environ` inline, and keep new config readers in the shape of the
+  ones already there.
 - Adding a setting: put it in `.env.example` with a placeholder and read it
   through the env helpers. Never re-implement the loading or the
-  environment-beats-file precedence — see *Environment Variables* in
-  `README.md` for how that layering works.
+  environment-beats-file precedence.
 - Changing what the page loads: anything served from a new origin, or any
   inline script or style, has to be reflected in the Content Security Policy,
-  and `{{ csp_nonce }}` comes before `'unsafe-inline'`. See *Content Security
-  Policy* in `README.md` for what the policy already allows.
+  and `{{ csp_nonce }}` comes before `'unsafe-inline'`.
 - Broader style guidance follows *Effective Python* — see
   https://github.com/SigmaQuan/Better-Python-59-Ways.
 
 **Frontend**
 
-- The Vite entry point is named in both `vite.config.js` and
-  `backend/templates/index.html`. Renaming it means updating both.
-- `publicDir` is disabled; static assets go through Django's staticfiles.
+- The Vite entry point is named in both the Vite config and the Django
+  template. Renaming it means updating both.
+- Static assets go through Django's staticfiles, not Vite's public directory.
+  Do not add a second static pipeline.
 - There is no JS linter or JS test runner. Frontend verification is the build
   plus the template and server e2e checks.
 
@@ -160,13 +161,13 @@ the reasoning comes from an external source.
   asserted. A test whose intent cannot be written in one sentence is testing
   more than one thing — split it.
 
-  `backend/tests/test_views.py` still carries an older `GIVEN:`/`WHEN:`/`THEN:`
-  form. That style is retired: write new tests with the outline above, and
-  convert a docstring you are already editing. Do not convert the rest as a
-  drive-by — a whole-file conversion is its own structural commit.
+  Some older tests still carry a `GIVEN:`/`WHEN:`/`THEN:` form. That style is
+  retired: write new tests with the outline above, and convert a docstring you
+  are already editing. Do not convert the rest as a drive-by — a whole-file
+  conversion is its own structural commit.
 
-- Settings-related tests reload `djangovue.settings` under `mock.patch.dict` —
-  reuse that pattern instead of asserting against process state.
+- Settings-related tests reload the settings module under a patched
+  environment — reuse that pattern instead of asserting against process state.
 
 ## Git and pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,12 +108,14 @@ the reasoning comes from an external source.
 - Configuration comes from `.env`, which `djangovue/settings.py` loads at import
   time via `load_env_file` from `djangovue/utils.py`. **Real environment
   variables always win over the file** — that is what lets Docker, Compose, CI,
-  and the `Makefile` override a single key. A new setting goes in `.env.example` and is read through the env
-  helpers; nothing should re-implement the loading.
+  and the `Makefile` override a single key. A new setting goes in
+  `.env.example` and is read through the env helpers; nothing should
+  re-implement the loading.
 - Responses are served under a Content Security Policy built by
   `build_csp_policy` in `djangovue/utils.py` and applied as `SECURE_CSP` in
   `djangovue/settings.py`. Anything that loads an asset from a new origin, or
-  adds an inline script or style, has to be reflected there — reach for `{{ csp_nonce }}` before reaching for `'unsafe-inline'`.
+  adds an inline script or style, has to be reflected there — reach for
+  `{{ csp_nonce }}` before reaching for `'unsafe-inline'`.
 - Broader style guidance follows *Effective Python* — see
   https://github.com/SigmaQuan/Better-Python-59-Ways.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# Architecture
+
+How the code fits together, for anyone — human or agent — who needs to know
+where a thing lives before changing it.
+
+This document covers implementation: modules, the seams between them, and the
+couplings that are not obvious from reading one file. It is deliberately not a
+setup guide. For installation, the command list, environment variable
+reference, and what the Content Security Policy allows, see `README.md`. For
+the rules about how to make a change here, see `AGENTS.md`.
+
+## Layout
+
+| Path | Contains |
+| --- | --- |
+| `djangovue/` | Project configuration: settings, URL root, WSGI/ASGI entry points, shared helpers |
+| `backend/` | The Django app: views, URLs, templates, tests |
+| `frontend/` | Vue source (`js/`) and image assets, built by Vite into `frontend/dist/` |
+| `scripts/` | End-to-end checks invoked by `make e2e` |
+
+`manage.py` and `djangovue/cli.py` are the same entry point twice. `cli.py` is
+installed as the `manage` console script through `[project.scripts]` in
+`pyproject.toml`, which is what makes `uv run manage <command>` work.
+`manage.py` calls the same entry point, so the conventional Django invocation
+still works.
+
+## Request path
+
+`djangovue/urls.py` mounts Django admin at `admin/` and includes
+`backend/urls.py` at the root. That app serves two routes:
+
+- `/` renders `backend/templates/index.html`, the shell that mounts the Vue
+  application.
+- `/healthz` returns a small JSON body for container readiness and liveness
+  probes. The production image depends on it.
+
+## Configuration
+
+`djangovue/settings.py` reads configuration from the process environment, with
+`.env` filling in what the environment does not already define. The layering
+and the variable reference are documented in *Environment Variables* in
+`README.md`; this section is about where the code lives.
+
+`djangovue/utils.py` holds the pieces settings is assembled from:
+
+- **`.env` parsing and loading.** Settings applies `.env` at import time rather
+  than leaving it to a task runner, which is what makes `uv run manage ...`,
+  Gunicorn, the test suite, and the e2e scripts all see the same configuration.
+  Variables already present in the environment are never overwritten, so a
+  container or CI job overrides a single key without a file at all. A missing
+  file is not an error.
+- **Typed environment readers** for booleans, lists, strings, and integers.
+  Each takes an optional `environ` mapping, which is what lets the tests
+  exercise them without mutating `os.environ`. New configuration readers should
+  keep that shape.
+- **Security policy construction.** The Content Security Policy is built here
+  and applied as `SECURE_CSP` in settings, using Django 6's native CSP support.
+  Host formatting is shared with the dev-server origins so IPv6 hosts get
+  bracketed correctly. HSTS preload settings are validated at import time — an
+  unacceptable combination raises rather than shipping a header the browser
+  preload list would reject.
+
+`SECRET_KEY` is required and raises `ImproperlyConfigured` when absent. This is
+why the mypy `django-stubs` plugin, which imports the settings module, needs an
+environment; `make typecheck` prepares one, bare `mypy` does not.
+
+## Frontend integration
+
+Vite builds `frontend/js/main.js` into `frontend/dist/` with a manifest, and
+`django-vite` resolves `{% vite_asset %}` tags in the Django template through
+`frontend/dist/.vite/manifest.json`. Three consequences follow:
+
+- **The entry path is named in two places** — the Vite config input and the
+  template tag. Renaming it means changing both.
+- **Rendering the template requires a build.** On a clean checkout the manifest
+  does not exist, so anything that renders `index.html` — Django checks, the
+  view tests, the e2e scripts — fails on asset resolution until the frontend
+  is built. That is not a code defect, and `make verify` builds first for
+  exactly this reason. CI builds in its own step before the same targets.
+- **`DJANGO_VITE_DEV_MODE` switches the source of assets.** Off, they resolve
+  through the built manifest; on, they point at the running Vite dev server and
+  the CSP widens to admit it. The `Makefile` forces it off for the targets that
+  must render against the manifest.
+
+`publicDir` is disabled in the Vite config: static assets are served through
+Django's staticfiles rather than copied by Vite, so there is one static
+pipeline instead of two.
+
+## Tests
+
+Python tests live in the `backend/tests/` package, one module per subject:
+views and routing, settings and environment handling, and security headers and
+policy construction. Settings-related tests reload the settings module under a
+patched environment rather than asserting against process state, because
+settings is evaluated at import time.
+
+`make e2e` adds two checks that the unit tests cannot cover: a template render
+against the built manifest, and a server boot smoke test.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 This is a starter project for Django with Vue.js. The frontend uses Vue 3 + Vite, and the backend uses
 Django 6 with environment-driven settings.
 
+For how the code fits together, see [ARCHITECTURE.md](ARCHITECTURE.md). For the
+rules on making changes here — including what agents must do — see
+[AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Why this starter in 2026?
 
 If you are starting a new web product in 2026, this stack is a pragmatic default:


### PR DESCRIPTION
## Summary

This PR introduces a new `ARCHITECTURE.md` document that explains how the codebase is organized and how its components fit together. It also refactors existing documentation in `AGENTS.md` and `README.md` to avoid duplication and establish clear ownership of different documentation topics.

## Key Changes

- **Added `ARCHITECTURE.md`**: A comprehensive guide covering:
  - Project layout and directory structure
  - Request path and routing flow
  - Configuration loading and environment variable handling
  - Frontend integration with Vite and django-vite
  - Test organization and structure
  
- **Refactored `AGENTS.md`**:
  - Added explicit references to `ARCHITECTURE.md` for implementation details
  - Clarified the distinction between rules (what to do) and implementation details (how it works)
  - Removed duplicated explanations of frontend asset resolution and configuration loading
  - Simplified guidance by pointing to `ARCHITECTURE.md` for structural information
  - Reorganized test guidance to reference the new test package structure
  - Improved clarity on settings-related test patterns

- **Updated `README.md`**:
  - Added introductory section linking to `ARCHITECTURE.md` and `AGENTS.md`
  - Directs readers to appropriate documentation based on their needs

## Notable Implementation Details

The refactoring establishes a clear documentation hierarchy:
- `README.md`: Setup, deployment, and environment variables
- `ARCHITECTURE.md`: How the code is organized and how components interact
- `AGENTS.md`: Rules and constraints for making changes
- `CONTRIBUTING.md`: Referenced but not modified

This prevents documentation drift by ensuring each topic lives in one place, making it easier to maintain consistency as the codebase evolves.

https://claude.ai/code/session_01XdF77HNw3HqdjtN51iMQDR