### PR TITLE
[bug fix add whitenoise to serve static files]

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ endpoint at `/healthz`. It ships without a `.env` file, so configuration is
 passed in at run time — `make docker-run` forwards your local one with
 `--env-file .env`, and any `-e` flag overrides a single key from it.
 
+By default, the container is configured to serve static files directly using WhiteNoise.
+For higher traffic production environments, you might want to consider moving your
+static files to a Google Cloud Storage (GCS) bucket or similar object storage.
+
 The Compose stack is for development: it mounts the working tree, runs
 `runserver` so edits reload, reads the same `.env`, and points Django at the
 Vite dev server running in the `frontend` service.

--- a/djangovue/settings.py
+++ b/djangovue/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS: list[str] = [
 
 MIDDLEWARE: list[str] = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     # Django 6.0 ships Content-Security-Policy support; the middleware reads
     # SECURE_CSP below and makes a per-request nonce available to templates.
     "django.middleware.csp.ContentSecurityPolicyMiddleware",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "dj-database-url>=2.2.0",
     "gunicorn>=23.0.0",
     "python-dotenv>=1.2.2",
+    "whitenoise>=6.12.0",
 ]
 
 [project.scripts]
@@ -89,3 +90,8 @@ plugins = ["mypy_django_plugin.main"]
 # The plugin imports these settings, which read .env at import time, so
 # `make typecheck` needs that file - the Makefile creates it from .env.example.
 django_settings_module = "djangovue.settings"
+
+[dependency-groups]
+dev = [
+    "django-stubs>=6.0.8",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,3 @@ plugins = ["mypy_django_plugin.main"]
 # The plugin imports these settings, which read .env at import time, so
 # `make typecheck` needs that file - the Makefile creates it from .env.example.
 django_settings_module = "djangovue.settings"
-
-[dependency-groups]
-dev = [
-    "django-stubs>=6.0.8",
-]

--- a/uv.lock
+++ b/uv.lock
@@ -201,11 +201,6 @@ dev = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "django-stubs" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
@@ -220,9 +215,6 @@ requires-dist = [
     { name = "whitenoise", specifier = ">=6.12.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "django-stubs", specifier = ">=6.0.8" }]
 
 [[package]]
 name = "gunicorn"

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,7 @@ dependencies = [
     { name = "django-vite" },
     { name = "gunicorn" },
     { name = "python-dotenv" },
+    { name = "whitenoise" },
 ]
 
 [package.optional-dependencies]
@@ -198,6 +199,11 @@ dev = [
     { name = "django-stubs", extra = ["compatible-mypy"] },
     { name = "mypy" },
     { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "django-stubs" },
 ]
 
 [package.metadata]
@@ -211,8 +217,12 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.1" },
+    { name = "whitenoise", specifier = ">=6.12.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "django-stubs", specifier = ">=6.0.8" }]
 
 [[package]]
 name = "gunicorn"
@@ -466,4 +476,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]


### PR DESCRIPTION
**What:** Added `whitenoise` dependency and `WhiteNoiseMiddleware` configuration. Also updated the README to mention using GCS buckets for static files in higher-traffic scenarios.
**Why:** Fixes 404 errors for static files in Cloud Run where Gunicorn does not serve static files by default.
**Verification:** Ran `make lint`, `make typecheck`, `make test`, and `make e2e` which all passed.
**Result:** The application now successfully serves static assets via WhiteNoise in production container setups.

---
*PR created automatically by Jules for task [8549233778257818606](https://jules.google.com/task/8549233778257818606) started by @mikebz*