### PR TITLE
fix: serve static files via WhiteNoise in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 # Build outputs
 frontend/bundles/*
 frontend/dist/
+staticfiles/
 build/
 
 # Vite

--- a/djangovue/settings.py
+++ b/djangovue/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS: list[str] = [
 
 MIDDLEWARE: list[str] = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     # Django 6.0 ships Content-Security-Policy support; the middleware reads
     # SECURE_CSP below and makes a per-request nonce available to templates.
     "django.middleware.csp.ContentSecurityPolicyMiddleware",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "dj-database-url>=2.2.0",
     "gunicorn>=23.0.0",
     "python-dotenv>=1.2.2",
+    "whitenoise>=6.12.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,7 @@ dependencies = [
     { name = "django-vite" },
     { name = "gunicorn" },
     { name = "python-dotenv" },
+    { name = "whitenoise" },
 ]
 
 [package.optional-dependencies]
@@ -211,6 +212,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.1" },
+    { name = "whitenoise", specifier = ">=6.12.0" },
 ]
 provides-extras = ["dev"]
 
@@ -466,4 +468,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
 ]


### PR DESCRIPTION
## Summary
Fixes 404 errors when serving static assets (e.g., `GET /static/main-Ca1Jf1uF.css`) in Cloud Run / production deployments.

## Root Cause
In production (`DEBUG=False`), Django's `staticfiles` app does not serve static files. Since Gunicorn is run directly without an Nginx front-end, requests to `/static/` returned 404.

## Changes
- Added `whitenoise>=6.12.0` dependency in `pyproject.toml` and updated `uv.lock`.
- Integrated `whitenoise.middleware.WhiteNoiseMiddleware` in `djangovue/settings.py`.
- Added `staticfiles/` to `.gitignore`.

## Verification
- Verified locally with Django test client using `DEBUG=0` that requests to `/static/main-Ca1Jf1uF.css` return `HTTP 200 OK` with proper `text/css` headers and content.
- Ran `make frontend-build && make verify` cleanly across linter (`ruff`, `black`), typecheck (`mypy`), unit tests, template check, and server smoke test.
- Note: Safari UI verification is outstanding.