### PR TITLE
[extract shared environment variable retrieval logic]

### DIFF
--- a/djangovue/utils.py
+++ b/djangovue/utils.py
@@ -55,6 +55,24 @@ def load_env_file(
     return applied
 
 
+def _get_env_value(
+    name: str,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Return the raw value of an environment variable.
+
+    Args:
+        name: The name of the environment variable.
+        environ: Optional mapping to use instead of `os.environ`.
+
+    Returns:
+        The raw string value of the environment variable, or None if missing.
+
+    """
+    env = os.environ if environ is None else environ
+    return env.get(name)
+
+
 def get_env_bool(
     name: str,
     *,
@@ -80,8 +98,7 @@ def get_env_bool(
         True
 
     """
-    env = os.environ if environ is None else environ
-    raw_value = env.get(name)
+    raw_value = _get_env_value(name, environ)
     if raw_value is None:
         return default
     return raw_value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
@@ -112,8 +129,7 @@ def get_env_list(
         ['local']
 
     """
-    env = os.environ if environ is None else environ
-    raw_value = env.get(name)
+    raw_value = _get_env_value(name, environ)
     if raw_value is None:
         return [] if default is None else list(default)
     return [s for s in map(str.strip, raw_value.split(",")) if s]
@@ -144,8 +160,7 @@ def get_env_str(
         '127.0.0.1'
 
     """
-    env = os.environ if environ is None else environ
-    raw_value = env.get(name)
+    raw_value = _get_env_value(name, environ)
     if raw_value is None or not raw_value.strip():
         return default
     return raw_value.strip()
@@ -177,8 +192,7 @@ def get_env_int(
         8000
 
     """
-    env = os.environ if environ is None else environ
-    raw_value = env.get(name)
+    raw_value = _get_env_value(name, environ)
     if raw_value is None:
         return default
     try:


### PR DESCRIPTION
**What:**
Extracted the duplicated logic for resolving the environment mapping and fetching the raw value into a new private helper `_get_env_value`.

**Why:**
This improves maintainability by centralizing the `os.environ` fallback and `.get()` retrieval into a single location, reducing duplication across `get_env_bool`, `get_env_list`, `get_env_str`, and `get_env_int`.

**Verification:**
Verified through doctests (`uv run python -m pytest --doctest-modules djangovue/utils.py`), unit tests (`make test`), integration tests (`make e2e`), as well as static type checking, formatting, and linting (`make format`, `make lint`, `make typecheck`).

**Result:**
The codebase now uses a unified helper for environment variable retrieval, maintaining the exact same functionality with less code duplication.

---
*PR created automatically by Jules for task [4671608835834539408](https://jules.google.com/task/4671608835834539408) started by @mikebz*