### PR TITLE
🧹 [fix misleading static files configuration test]

### DIFF
--- a/backend/tests/test_views.py
+++ b/backend/tests/test_views.py
@@ -4,6 +4,7 @@ Author: Mike Borozdin (mikebz@)
 """
 
 from django.conf import settings
+from django.core.management import call_command
 from django.test import Client, SimpleTestCase, TestCase
 
 
@@ -96,6 +97,12 @@ class ViteIntegrationTest(TestCase):
 
     Ensures build assets are properly integrated.
     """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Collect static files before running Vite integration tests."""
+        super().setUpClass()
+        call_command("collectstatic", interactive=False, verbosity=0)
 
     def test_vite_assets_are_loaded(self) -> None:
         """GIVEN: A built frontend with Vite.

--- a/backend/tests/test_views.py
+++ b/backend/tests/test_views.py
@@ -3,6 +3,7 @@
 Author: Mike Borozdin (mikebz@)
 """
 
+from django.conf import settings
 from django.test import Client, SimpleTestCase, TestCase
 
 
@@ -116,7 +117,7 @@ class ViteIntegrationTest(TestCase):
         """
         # This test ensures static file serving is configured
         # In production, this would be handled by a web server
-        response = self.client.get("/")
+        response = self.client.get(f"{settings.STATIC_URL}admin/css/base.css")
         self.assertEqual(response.status_code, 200)
 
 


### PR DESCRIPTION
🎯 **What:** Updated `test_static_files_configuration_works` to explicitly test static file serving by requesting an actual static asset rather than the root URL.
💡 **Why:** The previous test requested `/` (the root URL), which didn't actually verify that the static file configuration (`STATIC_URL` routing) worked correctly. Requesting an actual static file (like `admin/css/base.css`) ensures the static files routing is properly configured and functioning in testing.
✅ **Verification:** Verified by running `make test` which confirmed the change safely passed after `collectstatic` was run, and confirmed full suite functionality via `make e2e` and formatting via `make lint`. Code review confirmed it isolated the test to actual static delivery successfully.
✨ **Result:** The test suite now accurately reflects static asset delivery configuration and removes the misleading nature of the original test.

---
*PR created automatically by Jules for task [4255740079426771600](https://jules.google.com/task/4255740079426771600) started by @mikebz*