### PR TITLE
[code health: Fix broad Exception catch in load_env_file]

### DIFF
--- a/djangovue/utils.py
+++ b/djangovue/utils.py
@@ -40,7 +40,7 @@ def load_env_file(
     env = os.environ if environ is None else environ
     try:
         parsed = dotenv_values(path, encoding="utf-8-sig")
-    except Exception:
+    except (OSError, UnicodeDecodeError):
         return {}
 
     if not parsed:


### PR DESCRIPTION
**What:** Replaced broad Exception catch with specific OSError and UnicodeDecodeError in `load_env_file`.
**Why:** Improves maintainability by not silently swallowing unexpected errors. Only anticipated file system and encoding errors are now gracefully ignored.
**Verification:** Ran test suite (`make test`), e2e tests (`make e2e`), and linters (`make typecheck`, `make lint`).
**Result:** Code health issue resolved while preserving functionality.

---
*PR created automatically by Jules for task [10064591758524797386](https://jules.google.com/task/10064591758524797386) started by @mikebz*