### PR TITLE
[code health improvement description]

### DIFF
--- a/djangovue/settings.py
+++ b/djangovue/settings.py
@@ -7,7 +7,6 @@ for the production deployment checklist this module follows.
 Author: Mike Borozdin (mikebz@)
 """
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +40,7 @@ load_env_file(BASE_DIR / ".env")
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY: str | None = os.environ.get("SECRET_KEY")
+SECRET_KEY: str = get_env_str("SECRET_KEY", default="")
 if not SECRET_KEY:
     raise ImproperlyConfigured("SECRET_KEY environment variable must be set")
 


### PR DESCRIPTION
**What:** Replaced the usage of `os.environ.get("SECRET_KEY")` with `get_env_str("SECRET_KEY", default="")` in `djangovue/settings.py` and updated its type hint to `str`. Also removed the unused `import os`.

**Why:** Using `get_env_str` makes configuration more consistent with the rest of the file and enforces better type safety.

**Verification:** Ran `make verify`, which executed `ruff` (linter), `black` (formatter), `mypy` (type checker), and the full Django test suite (`make test` and `make e2e`). All checks passed successfully.

**Result:** The code health of the settings file is improved through consistent utility usage and clean type hints without any change to runtime behavior.

---
*PR created automatically by Jules for task [6600033711051951525](https://jules.google.com/task/6600033711051951525) started by @mikebz*